### PR TITLE
Objects of type "container" should always migrate as files, even if t…

### DIFF
--- a/src/converters/archival_object_converter.rb
+++ b/src/converters/archival_object_converter.rb
@@ -78,9 +78,7 @@ class ArchivalObjectConverter < Converter
 
       item = db[:item].where(:id => object[:id]).first
       if item[:dc_type] == 1 # Collection
-        if db[:file_folder].where(:item => item[:id]).count > 0
-          level = 'file'
-        end
+        level = 'file'
       end
 
       level


### PR DESCRIPTION
…here's no record beneath them in the DB.

See: https://www.pivotaltracker.com/story/show/123571971
