### PR TITLE
Add missing 'file_folder' to the list of instance types

### DIFF
--- a/src/converters/archival_object_converter.rb
+++ b/src/converters/archival_object_converter.rb
@@ -154,6 +154,7 @@ class ArchivalObjectConverter < Converter
       :physical_image => 'graphic_materials',
       :digital_object => 'digital_object',
       :browsing_object => 'digital_object_link', # made up - there aren't any of these anyway
+      :file_folder => 'mixed_materials',         # ???
     }
 
     def build_instances(object, db)


### PR DESCRIPTION
Ensures that we pick up barcodes for these.
