### PR TITLE
Digital objects - events, pids and linked_agents

### DIFF
--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -92,15 +92,9 @@ class DigitalObjectConverter < Converter
         digital_object[:pid]
       end
     else
-      Log.warn("Digital object doesn't have a pid: #{digital_object[:id]}.  Using object[:number] for digital_object_id instead.")
+      Log.warn("Digital object doesn't have a pid: #{digital_object[:id]}. Generating a random value for digital_object_id instead.")
 
-      if db[:digital_object].where(:item => object[:id]).all.length > 1
-        # FIXME these items have multiple digital objects perhaps implying digital object components
-        # just fudge some unique digital_object_ids for the moment
-        "#{object[:number]} [#{digital_object[:id]}]"
-      else
-        object[:number]
-      end
+      SecureRandom.hex
     end
   end
 

--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -185,8 +185,20 @@ class DigitalObjectConverter < Converter
   end
 
   def extract_linked_agents(object, item, digital_object, db)
-    # FIXME from Creators, implies need to import all old users as well?
-    []
+    begin
+      creator = db[:log].
+        filter(:audit_trail => object[:audit_trail], :action => 'create').
+        order(:id).select(:staff).first.
+        fetch(:staff)
+
+      [{
+         'role' => 'creator',
+         'ref' => Migrator.promise('staff_uri', creator.to_s),
+       }]
+    rescue
+      Log.warn("Digital object doesn't have a creator: #{digital_object[:id]}. Skipping linked agent for creator role.")
+      []
+    end
   end
 
   def extract_dates(object, item, digital_object, db)

--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -6,17 +6,21 @@ class DigitalObjectConverter < Converter
     Log.info("Going to process #{db[:digital_object].count} digital object records")
 
     db[:digital_object].each do |digital_object|
-      store.put_digital_object(build_from_digital_object(digital_object, store))
+      item = db[:item][:id => digital_object[:item]]
+      object = db[:object][:id => item[:id]]
+
+      store.put_digital_object(build_from_digital_object(object, item, digital_object, store))
+
+      build_events(object, item, digital_object).each do |event|
+        store.put_event(event)
+      end
     end
   end
 
   private
 
-  def build_from_digital_object(digital_object, store)
-    item = db[:item][:id => digital_object[:item]]
-    object = db[:object][:id => item[:id]]
-
-    record = {
+  def build_from_digital_object(object, item, digital_object, store)
+    {
       'id' => digital_object[:id].to_s,
       'digital_object_id' => extract_digital_object_id(object, item, digital_object, db),
       'level' => extract_level(object, item, digital_object, db),
@@ -30,15 +34,6 @@ class DigitalObjectConverter < Converter
       'notes' => extract_notes(object, item, digital_object, db),
       'user_defined' => extract_user_defined(object, item, digital_object, db),
     }.merge(extract_audit_info(object, db))
-
-    # FIXME Need to generate events:
-    # CATALOGUED EVENT 'cataloged_date' => nil, #File Creation Date
-    #                  'cataloged_note' => Digital Objects Notes
-    # PROSESSED EVENT 'processed_date' => nil, #Stabilization - date
-    #                 'processors' => nil, #Stabilization - by
-    # RIGHTS_TRANSFERRED EVENT: 'rights_transferred' => nil, #Digital Objects Rights
-
-    record
   end
 
 
@@ -230,9 +225,6 @@ class DigitalObjectConverter < Converter
 
     # TODO string_3 => Stabilization Applications Other
 
-    # text_1 => Stabilization Notes
-    user_defined['text_1'] = digital_object[:stabilization_notes]
-
     # text_2 => Digital Objects Original Filename
     user_defined['text_2'] = digital_object[:original_filename]
 
@@ -245,13 +237,6 @@ class DigitalObjectConverter < Converter
     if digital_object[:stabilization_procedure]
       stabilization_procedure = db[:stabilization_procedure][:id => digital_object[:stabilization_procedure]]
       user_defined['enum_3'] = "#{stabilization_procedure[:code]} #{stabilization_procedure[:name]}"
-    end
-
-    # enum_4 => Applications Media Image
-    if digital_object[:media_app]
-      media_app = db[:application][:id => digital_object[:media_app]]
-
-      user_defined['enum_4'] = media_app[:name]
     end
 
     user_defined
@@ -285,5 +270,93 @@ class DigitalObjectConverter < Converter
     end
 
     audit_fields
+  end
+
+
+  def build_events(object, item, digital_object)
+    events = []
+
+    # not all records have a 'created' log item,
+    # so just grab their first one...
+    create_timestamp = db[:log].
+      filter(:audit_trail => object[:audit_trail]).
+      order(:id).select(:timestamp).first.
+      fetch(:timestamp)
+
+    # processed event
+    if digital_object[:stabilized_by] && digital_object[:stabilized_procedure]
+      processed_event = {
+        'event_type' => 'processed',
+        'outcome_note' => digital_object[:stabilization_notes],
+        'linked_agents' => [{
+                              'ref' => Migrator.promise('staff_uri', digital_object[:stabilized_by].to_s),
+                              'role' => 'implementer',
+                            }],
+        'linked_records' => [{
+                               'ref' => Migrator.promise('digital_object_uri', digital_object[:id].to_s),
+                               'role' => 'outcome',
+                             }]
+      }
+
+      if digital_object[:stabilization_date]
+        processed_event['date'] = {
+          'date_type' => 'single',
+          'label' => 'event',
+          'begin' => digital_object[:stabilization_date],
+        }
+      else
+        processed_event['timestamp'] = Utils.convert_timestamp_for_db(create_timestamp)
+      end
+
+      if digital_object['stabilized_procedure']
+        processed_event['linked_agents'] << {
+          'ref' => Migrator.promise('stabilization_procedure_uri', digital_object[:stabilized_procedure].to_s),
+          'role' => 'executing_program',
+        }
+      end
+
+      events << processed_event
+    end
+
+    # capture event
+    # Event type = capture; event date/time specifier = UTC;
+    # agent link role = executing program;
+    # agent = all software options currently in CIDER need to migrate as agents
+    if digital_object[:media_app]
+      events << {
+        'event_type' => 'capture',
+        'timestamp' => Utils.convert_timestamp_for_db(create_timestamp),
+        'linked_agents' => [{
+                              'ref' => Migrator.promise('application_uri', digital_object[:media_app].to_s),
+                              'role' => 'executing_program',
+                            }],
+        'linked_records' => [{
+                               'ref' => Migrator.promise('digital_object_uri', digital_object[:id].to_s),
+                               'role' => 'outcome',
+                             }]
+
+      }
+    end
+
+    # Event type = virus check;
+    # event date/time specifier = UTC;
+    # agent link role = executing program;
+    # agent = all software options currently in CIDER need to migrate as agents
+    if digital_object[:virus_app]
+      events << {
+        'event_type' => 'virus_check',
+        'timestamp' => Utils.convert_timestamp_for_db(create_timestamp),
+        'linked_agents' => [{
+                              'ref' => Migrator.promise('application_uri', digital_object[:virus_app].to_s),
+                              'role' => 'executing_program',
+                            }],
+        'linked_records' => [{
+                              'ref' => Migrator.promise('digital_object_uri', digital_object[:id].to_s),
+                              'role' => 'outcome',
+                             }]
+      }
+    end
+
+    events
   end
 end

--- a/src/converters/software_converter.rb
+++ b/src/converters/software_converter.rb
@@ -1,0 +1,54 @@
+class SoftwareConverter < Converter
+
+  def call(store)
+    Log.info("Going to process #{db[:application].count} application records")
+
+    db[:application].each do |application|
+      store.put_agent_software(build_from_application(application), 'application')
+    end
+
+    Log.info("Going to process #{db[:stabilization_procedure].count} stabilization_procedure records")
+    db[:stabilization_procedure].each do |procedure|
+      store.put_agent_software(build_from_stabilization_procedure(procedure), 'stabilization_procedure')
+    end
+  end
+
+  private
+
+  def build_from_application(application)
+    {
+      'id' => "#{application[:id]}",
+      'jsonmodel_type' => 'agent_software',
+      'agent_type' => 'agent_software',
+      'names' => [{
+        'sort_name_auto_generate' => true,
+        'jsonmodel_type' => 'name_software',
+        'software_name' => application[:name],
+        'source' => 'cider',
+      }],
+      'notes' => [{
+        'jsonmodel_type' => 'note_bioghist',
+        'label' => 'Function',
+        'subnotes' => [{
+          'jsonmodel_type' => 'note_text',
+          'content' => application[:function],
+        }]
+      }]
+    }
+  end
+
+  def build_from_stabilization_procedure(procedure)
+    {
+      'id' => "#{procedure[:id]}",
+      'jsonmodel_type' => 'agent_software',
+      'agent_type' => 'agent_software',
+      'names' => [{
+                    'sort_name_auto_generate' => true,
+                    'jsonmodel_type' => 'name_software',
+                    'software_name' => procedure[:name],
+                    'authority_id' => procedure[:code],
+                    'source' => 'cider',
+                  }]
+    }
+  end
+end

--- a/src/converters/staff_converter.rb
+++ b/src/converters/staff_converter.rb
@@ -1,0 +1,31 @@
+class StaffConverter < Converter
+  def call(store)
+    Log.info("Going to process #{db[:staff].count} staff records")
+
+    db[:staff].each do |staff|
+      store.put_agent_person(build_agent(staff), 'staff')
+    end
+  end
+
+  private
+
+  def build_agent(staff)
+    {
+      'id' => "#{staff[:id]}",
+      'jsonmodel_type' => 'agent_person',
+      'agent_type' => 'agent_person',
+      'names' => [build_name(staff)],
+    }
+  end
+
+  def build_name(staff)
+    {
+      'sort_name_auto_generate' => true,
+      'jsonmodel_type' => 'name_person',
+      'primary_name' => staff[:last_name],
+      'rest_of_name' => staff[:first_name],
+      'name_order' => 'inverted',
+      'source' => 'cider',
+    }
+  end
+end

--- a/src/converters/user_importer.rb
+++ b/src/converters/user_importer.rb
@@ -74,7 +74,7 @@ class Users
   def groups
     return @groups if @groups
 
-    @groups = JSONModel::HTTP.get_json("/repositories/2/groups")
+    @groups = JSONModel::HTTP.get_json("/repositories/#{$repo_id}/groups")
 
     @groups
   end

--- a/src/migration_store.rb
+++ b/src/migration_store.rb
@@ -17,12 +17,15 @@ class MigrationStore
       :digital_object =>  MarshalStore.new(File.join(basedir, "digital_objects")),
       :event =>  MarshalStore.new(File.join(basedir, "events")),
       :agent_person_record_context => MarshalStore.new(File.join(basedir, "agent_person")),
+      :agent_person_staff => MarshalStore.new(File.join(basedir, "agent_person_staff")),
       # :agent_person_creator => MarshalStore.new(File.join(basedir, "agent_creator_people")),
       # :agent_person_acknowledger => MarshalStore.new(File.join(basedir, "agent_acknowledger_people")),
       :agent_corporate_entity_record_context => MarshalStore.new(File.join(basedir, "agent_corporate_entity")),
       # :agent_corporate_entity_contact => MarshalStore.new(File.join(basedir, "agent_corporate_entities_contact")),
       # :agent_corporate_entity_creator => MarshalStore.new(File.join(basedir, "agent_corporate_entities_creator")),
       :agent_family_record_context => MarshalStore.new(File.join(basedir, "agent_family")),
+      :agent_software_application => MarshalStore.new(File.join(basedir, "agent_software_application")),
+      :agent_software_stabilization_procedure => MarshalStore.new(File.join(basedir, "agent_software_stabilization_procedure")),
       :vocabulary =>  MarshalStore.new(File.join(basedir, "vocabularies")),
       :subject =>  MarshalStore.new(File.join(basedir, "subjects")),
     }
@@ -240,6 +243,17 @@ class MigrationStore
 
     if deliver_promise('subject_uri', record['id'], uri)
       put(:subject, record)
+    end
+  end
+
+
+  def put_agent_software(record, role = 'application')
+    uri = "/agents/software/import_#{SecureRandom.hex}"
+
+    if put(:"agent_software_#{role}", record)
+      store = @stores.fetch(:"agent_software_#{role}")
+
+      deliver_promise("#{role}_uri", record['id'], uri)
     end
   end
 

--- a/src/migrator.rb
+++ b/src/migrator.rb
@@ -79,6 +79,14 @@ class Migrator
         AgentConverter.new(@cider_db).call(store)
       end
 
+      chatty("Extracting Agent Sofware records from CIDER Application table", store, tree_store) do
+        SoftwareConverter.new(@cider_db).call(store)
+      end
+
+      chatty("Extracting Agent records from CIDER Staff table", store, tree_store) do
+        StaffConverter.new(@cider_db).call(store)
+      end
+
       chatty("Extracting Subject records from various CIDER tables", store, tree_store) do
         SubjectConverter.new(@cider_db).call(store)
       end


### PR DESCRIPTION
To support digital object events, I've migrated the CIDER `application` and `stabilization_procedure` tables as agent software records and also migrated the CIDER `staff` records as agent people.  These agents can now be linked into the DO events as `executing_program` or `implementer` respectively.

I've also tinkered the `digital_object_id` extraction to generate a unique value if the CIDER pid is empty.

Lastly, I've followed the mapping to add a linked_agent with a 'creator' role for the CIDER staff member who created the record (from the `audit_trail` where action == create).
