### PR TITLE
Ensure start before end date and fix broken event date

### DIFF
--- a/src/converters/archival_object_converter.rb
+++ b/src/converters/archival_object_converter.rb
@@ -113,8 +113,10 @@ class ArchivalObjectConverter < Converter
         "from object o, item i where o.id = i.id and o.number like '#{object[:number]}%'"
       result = db.fetch(dates_query).first
       if result[:date_from]
-        dates << Dates.range(result[:date_from], (result[:date_to] || result[:date_from_to])).merge({'date_type' => 'inclusive',
-                                                                                                     'label' => 'creation'})
+        from = [result[:date_from], result[:date_from_to], result[:date_to]].compact.min
+        to = [result[:date_from], result[:date_from_to], result[:date_to]].compact.max
+        dates << Dates.range(from, to).merge({'date_type' => 'inclusive',
+                                              'label' => 'creation'})
       end
 
       dates.compact!

--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -292,7 +292,7 @@ class DigitalObjectConverter < Converter
                              }]
       }
 
-      if digital_object[:stabilization_date]
+      if digital_object[:stabilization_date] && digital_object[:stabilization_date] != ""
         processed_event['date'] = {
           'date_type' => 'single',
           'label' => 'event',


### PR DESCRIPTION
- Ensure start date before end date on archival object series/subseries inclusive date
- Fix empty start date being added to digital object processed events
