### PR TITLE
Fix authority_name note not applying for names that contain a backslash

### DIFF
--- a/src/converters/agent_converter.rb
+++ b/src/converters/agent_converter.rb
@@ -31,7 +31,7 @@ class AgentConverter < Converter
       # e.g., /printer\author - into the notes field and out of the name,
       # for both people and corporate entities
       if name =~ /\\/
-        parts = name.split(/\\/)[0]
+        parts = name.split(/\\/)
         name = parts[0]
         note = [parts[1..-1], note].flatten.compact.join("; ")
       end


### PR DESCRIPTION
... and are split to return both the name and note.

Also, perhaps not a big issue, but authority_name notes are lost if the agent conflicts with an already imported RCR.  Do we want to merge things at this point?
