### PR TITLE
Tinkering digital object events and user defined fields

### DIFF
--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -216,15 +216,18 @@ class DigitalObjectConverter < Converter
     location = extract_location(digital_object, db)
     user_defined['text_1'] = location[:barcode]
 
+    # DISABLED AS WE DON'T NEED TO MIGRATE THESE ANYMORE
+    # https://www.pivotaltracker.com/story/show/121256939
+    #
     # text_2 => Relationships PID
-    relationships = db[:digital_object_relationship].
-                      join(:relationship_predicate, :relationship_predicate__id => :digital_object_relationship__predicate).
-                      where(:digital_object_relationship__digital_object => digital_object[:id]).
-                      select(:digital_object_relationship__pid, :relationship_predicate__predicate)
-    if relationships.count > 0
-      pids = relationships.collect{|rel| "#{rel[:predicate]} #{rel[:pid]}" }.uniq.sort
-      user_defined['text_2'] = pids.join("; ")
-    end
+    # relationships = db[:digital_object_relationship].
+    #                   join(:relationship_predicate, :relationship_predicate__id => :digital_object_relationship__predicate).
+    #                   where(:digital_object_relationship__digital_object => digital_object[:id]).
+    #                   select(:digital_object_relationship__pid, :relationship_predicate__predicate)
+    # if relationships.count > 0
+    #   pids = relationships.collect{|rel| "#{rel[:predicate]} #{rel[:pid]}" }.uniq.sort
+    #   user_defined['text_2'] = pids.join("; ")
+    # end
 
     # text_3 => Other Applications
     applications = db[:digital_object_application].where(:digital_object => digital_object[:id])

--- a/src/migrator.rb
+++ b/src/migrator.rb
@@ -75,6 +75,12 @@ class Migrator
       store = MigrationStore.new(store_dir)
       tree_store = TreeStore.new(store)
 
+      chatty("Create DCA staff agent", store, tree_store) do
+        agent = build_dca_staff_agent
+        uri = store.put_agent_person(agent)
+        store.deliver_promise('dca_staff_agent_uri', agent['id'], uri)
+      end
+
       chatty("Extracting Agent records from CIDER RCRs and authorized names", store, tree_store) do
         AgentConverter.new(@cider_db).call(store)
       end
@@ -135,6 +141,27 @@ class Migrator
     $stderr.puts("Bytes in tree_store: #{tree_store.byte_size}")
 
     Log.info("Finished: #{description}")
+  end
+
+  def build_dca_staff_agent
+    {
+      'id' => 'dca_staff',
+      'jsonmodel_type' => 'agent_person',
+      'names' => [{
+                    'sort_name_auto_generate' => true,
+                    'jsonmodel_type' => 'name_person',
+                    'primary_name' => 'DCA Staff',
+                    'name_order' => 'inverted',
+                    'source' => 'local',
+                  }],
+      'notes' => [{
+                    'jsonmodel_type' => 'note_bioghist',
+                    'subnotes' => [{
+                                     'jsonmodel_type' => 'note_text',
+                                     'content' => 'This is a dummy agent to allow creation of orphaned records'
+                                   }]
+                  }]
+    }
   end
 
 end


### PR DESCRIPTION
- don't migrate digital_object_relationship data to user_defined['text_2'], this data is ok be lost forever
- create a dummy DCA Staff agent and link it to digital object processed events without an agent so we don't lose any stabilization data
