### PR TITLE
Reword the digital object stabilization events

### DIFF
--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -350,10 +350,18 @@ class DigitalObjectConverter < Converter
     end
 
     if digital_object[:stabilization_procedure]
-      processed_event['linked_agents'] << {
-        'ref' => Migrator.promise('stabilization_procedure_uri', digital_object[:stabilization_procedure].to_s),
-        'role' => 'executing_program',
-      }
+      # stabilization_procedure can be either:
+      #   1	ACC-007	Digital Media Stabilization
+      #   2	ACC-009	Digital Network Stabilization
+      # if Digital Media Stabilization, then event type is Stabilized - Network Transfer
+      # if Digital Network Stabilization, then event type is Stabilized - Digital Media
+      if digital_object[:stabilization_procedure] == 1
+        processed_event['event_type'] = 'Stabilized - Digital Media'
+      elsif digital_object[:stabilization_procedure] == 2
+        processed_event['event_type'] = 'Stabilized - Network Transfer'
+      else
+        Log.warn("Digital object stabilization_procedure not handled: #{digital_object[:stabilization_procedure]}")
+      end
     end
 
     if processed_event['linked_agents'].empty?

--- a/src/converters/software_converter.rb
+++ b/src/converters/software_converter.rb
@@ -6,11 +6,6 @@ class SoftwareConverter < Converter
     db[:application].each do |application|
       store.put_agent_software(build_from_application(application), 'application')
     end
-
-    Log.info("Going to process #{db[:stabilization_procedure].count} stabilization_procedure records")
-    db[:stabilization_procedure].each do |procedure|
-      store.put_agent_software(build_from_stabilization_procedure(procedure), 'stabilization_procedure')
-    end
   end
 
   private
@@ -35,21 +30,6 @@ class SoftwareConverter < Converter
           'content' => application[:function],
         }]
       }]
-    }
-  end
-
-  def build_from_stabilization_procedure(procedure)
-    {
-      'id' => "#{procedure[:id]}",
-      'jsonmodel_type' => 'agent_software',
-      'agent_type' => 'agent_software',
-      'names' => [{
-                    'sort_name_auto_generate' => true,
-                    'jsonmodel_type' => 'name_software',
-                    'software_name' => procedure[:name],
-                    'authority_id' => procedure[:code],
-                    'source' => 'cider',
-                  }]
     }
   end
 end

--- a/src/migration_store.rb
+++ b/src/migration_store.rb
@@ -25,7 +25,6 @@ class MigrationStore
       # :agent_corporate_entity_creator => MarshalStore.new(File.join(basedir, "agent_corporate_entities_creator")),
       :agent_family_record_context => MarshalStore.new(File.join(basedir, "agent_family")),
       :agent_software_application => MarshalStore.new(File.join(basedir, "agent_software_application")),
-      :agent_software_stabilization_procedure => MarshalStore.new(File.join(basedir, "agent_software_stabilization_procedure")),
       :vocabulary =>  MarshalStore.new(File.join(basedir, "vocabularies")),
       :subject =>  MarshalStore.new(File.join(basedir, "subjects")),
     }


### PR DESCRIPTION
Refer to the digital_object.stabilization_procedure value to determine the event type.  It was previously 'processed' but will now be 'Stabilized - Network Transfer' or 'Stabilized - Digital Media' depending on the referent db[:stabilization_procedure].  Also, we no longer import these stabilization_procedure entries as agent_software records.
