### PR TITLE
authority_name refinements

### DIFF
--- a/src/converters/agent_converter.rb
+++ b/src/converters/agent_converter.rb
@@ -415,6 +415,12 @@ class AgentConverter < Converter
       return true
     end
 
+    if name =~ /\A(Department|Dept)/i
+      # Anything starting with Department or Dept
+      # is a corporate entity
+      return false
+    end
+
     if name =~ /congress/i
       # Anything with the word "Congress" in the name (NOT the notes)
       # is a corporate entity
@@ -460,6 +466,14 @@ class AgentConverter < Converter
     end
   end
 
+  def subject?(name)
+    if name =~ /--/
+      return true
+    end
+
+    false
+  end
+
   def call(store)
     Log.info("Going to process #{db[:record_context].count} agent records")
 
@@ -472,7 +486,9 @@ class AgentConverter < Converter
     end
 
     db[:authority_name].each do |authority|
-      if person?(authority[:name], authority[:note])
+      if subject?(authority[:name])
+        # do nothing! we only want agent-like items
+      elsif person?(authority[:name], authority[:note])
         AgentPerson.new.from_authority_name(authority, db, store, agent_registry)
       else
         AgentCorporateEntity.new.from_authority_name(authority, db, store, agent_registry)

--- a/src/converters/authority_name.rb
+++ b/src/converters/authority_name.rb
@@ -1,0 +1,74 @@
+class AuthorityName
+
+  def self.person?(name, note)
+    if note =~ /man|woman|male|female/i
+      # Anything with "man" "woman" "male" or "female" in the notes field is
+      # likely a person, not a corporate entity
+      return true
+    end
+
+    if note =~ /last name only|first name unknown/i
+      # "Last name only" and "first name unknown" are people
+      return true
+    end
+
+    if name =~ /\A(Department|Dept)/i
+      # Anything starting with Department or Dept
+      # is a corporate entity
+      return false
+    end
+
+    if name =~ /congress/i
+      # Anything with the word "Congress" in the name (NOT the notes)
+      # is a corporate entity
+      return false
+    end
+
+    # Anything with "author" in the name or notes is likely a person
+    # (exceptions noted; make sure to limit to "author" or you'll accidentally
+    # get "authority" as well, and those should stay corporate)
+    if name =~ /authority/i || note =~ /authority/i
+      return false
+    end
+    if name =~ /author/i || note =~ /author/i
+      return true
+    end
+
+    # Anything with an ampersand standing alone ot the html encoding for an
+    # ampersand (&amp; ) is almost certainly a corporate entity
+    # (ex: Skidmore, Owings & Merrill). (Careful to limit to
+    # space-ampersand-space or &amp; or you'll also get the html encoding for
+    # special characters, like &#00E4;)
+    if name =~ /\s&\s|&amp;/
+      return false
+    end
+
+    if name =~ /[0-9]{4}/
+      # life dates
+      return true
+    end
+
+    bits = name.split(',')
+
+    if bits.length > 2
+      false
+    elsif bits.length <= 1
+      false
+    elsif bits[0].include?(" ")
+      false
+    elsif bits[1].split(" ").length > 3
+      false
+    else
+      true
+    end
+  end
+
+  def self.subject?(name)
+    if name =~ /--/
+      return true
+    end
+
+    false
+  end
+
+end


### PR DESCRIPTION
- names starting with 'Department' or 'Dept' are corporate entities
- names with '--' are subjects

Create subjects from those matching '--'.  And then link the item_authority_name relationships as either agent_links or subjects.

Delivers https://www.pivotaltracker.com/story/show/128102297
