### PR TITLE
Ensure all 'Groups' come through as 'Files'

### DIFF
--- a/src/converters/archival_object_converter.rb
+++ b/src/converters/archival_object_converter.rb
@@ -132,7 +132,7 @@ class ArchivalObjectConverter < Converter
     end
 
     def find_level(object, item, db)
-      if item[:is_group] == 1
+      if item[:is_group] == '1' # is_group is an enum and comes through as a string
         # Groups always migrate as files
         # See: https://www.pivotaltracker.com/n/projects/1592339
         'file'


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/123586401.

We check is_group, but need to compare to a string `'1'` as it's an enum and comes through as a string 🎱 😖 
