### PR TITLE
Add item's dates as either a single or inclusive date 

### DIFF
--- a/src/converters/archival_object_converter.rb
+++ b/src/converters/archival_object_converter.rb
@@ -79,6 +79,24 @@ class ArchivalObjectConverter < Converter
 
       if item
         dates << Dates.enclosed_range(db, item[:id])
+
+        # add the item's dates as a creation single/inclusive date
+        # only from date so show as single
+        if item[:item_date_from] && !item[:item_date_to]
+          dates << Dates.single(item[:item_date_from]).merge({
+            'label' => 'creation',
+            'date_type' => 'single',
+          })
+        # both or only to date so show as inclusive
+        elsif item[:item_date_to]
+          dates << {
+            'jsonmodel_type' => 'date',
+            'date_type' => 'inclusive',
+            'begin' => item[:item_date_from],
+            'end' => item[:item_date_to],
+            'label' => 'creation',
+          }
+        end
       end
 
       dates.compact!


### PR DESCRIPTION
New mapping for item requests mappings:
- End date  date = creation, type = inclusive, end
- Start date    date = creation, type = single or inclusive, begin

If only start date, then single date. If both, then inclusive. If only end date (1 in DB), then inclusive without start date.

This is on top of the calculated enclosed range for an item.

Delivers https://www.pivotaltracker.com/story/show/128297803 and https://www.pivotaltracker.com/story/show/128297809.
