### PR TITLE
Migrate digital object formats consistently

### DIFF
--- a/src/converters/digital_object_converter.rb
+++ b/src/converters/digital_object_converter.rb
@@ -168,8 +168,12 @@ class DigitalObjectConverter < Converter
 
   def extract_file_extension(object, item, digital_object, db)
     if digital_object[:file_extension]
+      # If there's a file extension set, we'll use that.
       ext = db[:file_extension][:id => digital_object[:file_extension]][:extension]
-      # drop the leading '.'
+      # drop the leading '.' and '>' (some weird entries in the file_extension table...)
+      ext.sub(/^[.>]+/, "")
+
+    elsif !digital_object[:original_filename].to_s.empty? && (ext = File.extname(digital_object[:original_filename].downcase))
       ext.sub(/^\./, "")
     else
       nil


### PR DESCRIPTION
It turns out we can't completely rely on the `file_extension` column to
be set in digital objects.  However, many rows that are missing a value
for that column do have a value for the `original_filename` column, so
we can derive an extension from that.

 :cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
:cake: :cake: :cake: :cake: :cake: :cake: :cake: :cake:
