### PR TITLE
Rework archival object date migration

### DIFF
--- a/src/converters/dates.rb
+++ b/src/converters/dates.rb
@@ -28,10 +28,6 @@ class Dates
 
 
   def self.enclosed_range(db, id)
-    # don't need to calculate range if item doesn't have descendants
-    return if db[:enclosure].filter(:ancestor => id).count == 1
-
-
     # derived dates > date_type = inclusive, date_label = creation
     # creation dates are derived. see:
     # lib/CIDER/Schema/Result/ObjectWithDerivedFields

--- a/src/converters/dates.rb
+++ b/src/converters/dates.rb
@@ -39,7 +39,15 @@ class Dates
       from = [result[:date_from], result[:date_from_to], result[:date_to]].map {|s| Utils.trim(s) }.compact.min[0,4]
       to = [result[:date_from], result[:date_from_to], result[:date_to]].map {|s| Utils.trim(s) }.compact.max[0,4]
 
-      range(from, to, 'creation', 'inclusive')
+      date = range(from, to, 'creation', 'inclusive')
+
+      # if item doesn't have any children (only one descendant, itself)
+      if db[:enclosure].filter(:ancestor => id).count == 1
+        # then merge in the item's circa value
+        date['certainty'] = 'approximate' if result[:circa] == '1'
+      end
+
+      date
     end
   end
 


### PR DESCRIPTION
After reviewing records in CIDER, it became clear that only certain records have the "enclosed"/derived date range.  These were series, sub-series, groups and file folders. I've updated the code to reflect this. 

If an item is neither of those, I simply create a range or single date based on that item's date values.

I've also cleaned up the 'circa' dates.  These are only applied at the lower item level.  I no longer apply 'approximate' to any derived dates... but for one exception!  There are some file_folders with no children that should have only their dates migrated, rather than the derived dates.  These dates apply the item's 'circa' state. Example: UA001.013.044.00043 (Circa 1972–1993).
